### PR TITLE
feat: Implement interleaving loom testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1230,7 @@ dependencies = [
  "bytes",
  "get-port",
  "higgins-codec",
+ "loom",
  "prost",
  "riskless",
  "rkyv",
@@ -1679,6 +1694,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lz4-sys"
@@ -2375,6 +2403,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3415,6 +3449,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3481,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3454,6 +3521,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3521,6 +3598,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if",
  "generator",
+ "pin-utils",
  "scoped-tls",
  "tracing",
  "tracing-subscriber",

--- a/higgins-core/Cargo.toml
+++ b/higgins-core/Cargo.toml
@@ -17,7 +17,7 @@ tracing-subscriber = "0.3.19"
 uuid = { version = "1.16.0", features = ["v4"] }
 
 # Higgins 
-higgins-codec = {path = "../higgins-codec"}
+higgins-codec = { path = "../higgins-codec" }
 prost = "0.13.5"
 thiserror = "2.0.12"
 rocksdb = "0.23.0"
@@ -28,3 +28,4 @@ rkyv = "0.8.10"
 get-port = "4.0.0"
 tempfile = "3.10"
 tracing-test = "0.2.5"
+loom = "0.7.2"

--- a/higgins-core/Cargo.toml
+++ b/higgins-core/Cargo.toml
@@ -28,4 +28,4 @@ rkyv = "0.8.10"
 get-port = "4.0.0"
 tempfile = "3.10"
 tracing-test = "0.2.5"
-loom = "0.7.2"
+loom = { version = "0.7.2", features = ["futures"] }

--- a/higgins-core/tests/common/mod.rs
+++ b/higgins-core/tests/common/mod.rs
@@ -1,0 +1,144 @@
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use bytes::BytesMut;
+use higgins_codec::{CreateSubscriptionRequest, TakeRecordsRequest};
+use higgins_codec::{Message, ProduceRequest, message::Type};
+use prost::Message as _;
+use std::net::TcpStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub fn produce(stream: &[u8], partition: &[u8], payload: &[u8], socket: &mut TcpStream) {
+    let produce_request = ProduceRequest {
+        partition_key: partition.to_vec(),
+        payload: payload.to_vec(),
+        stream_name: stream.to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(1024);
+
+    Message {
+        r#type: Type::Producerequest as i32,
+        produce_request: Some(produce_request),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).unwrap();
+
+    let n = socket.read(&mut read_buf).unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Produceresponse => {
+            let message = message.produce_response;
+
+            tracing::info!("Received produce response: {:#?}", message);
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    }
+}
+
+pub fn create_subscription(
+    stream: &[u8],
+    socket: &mut TcpStream,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let create_subscription = CreateSubscriptionRequest {
+        offset: None,
+        offset_type: 0,
+        timestamp: None,
+        stream_name: stream.to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(1024);
+
+    Message {
+        r#type: Type::Createsubscriptionrequest as i32,
+        create_subscription_request: Some(create_subscription),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)?;
+
+    let _result = socket.write_all(&write_buf)?;
+
+    let n = socket.read(&mut read_buf).unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    let sub_id = match Type::try_from(message.r#type).unwrap() {
+        Type::Createsubscriptionresponse => {
+            let sub_id = message
+                .create_subscription_response
+                .unwrap()
+                .subscription_id;
+
+            tracing::info!("Got the sub_id: {:#?}", sub_id);
+
+            sub_id.unwrap()
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    };
+
+    Ok(sub_id)
+}
+
+pub fn consume(
+    sub_id: Vec<u8>,
+    socket: &mut TcpStream,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let take_request = TakeRecordsRequest {
+        n: 1,
+        subscription_id: sub_id,
+        stream_name: "update_customer".as_bytes().to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(8048);
+
+    Message {
+        r#type: Type::Takerecordsrequest as i32,
+        take_records_request: Some(take_request),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).unwrap();
+
+    let n = socket.read(&mut read_buf)?;
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    let result = match Type::try_from(message.r#type).unwrap() {
+        Type::Takerecordsresponse => {
+            tracing::info!("Receieved a take records response!");
+
+            let take_records_response = message.take_records_response.unwrap();
+
+            tracing::info!("Records_Response: {:#?}", take_records_response);
+
+            let record = take_records_response.records.iter().nth(0).unwrap();
+
+            record.data.clone()
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    };
+
+    Ok(result)
+}

--- a/higgins-core/tests/interleaving_produce_consume.rs
+++ b/higgins-core/tests/interleaving_produce_consume.rs
@@ -1,0 +1,249 @@
+use std::time::Duration;
+
+use bytes::BytesMut;
+use get_port::{Ops, Range, tcp::TcpPort};
+use higgins::run_server;
+use higgins_codec::{
+    CreateConfigurationRequest, CreateSubscriptionRequest, Message, Ping, ProduceRequest,
+    TakeRecordsRequest, message::Type,
+};
+use prost::Message as _;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+use tracing_test::traced_test;
+
+#[tokio::test]
+#[traced_test]
+async fn can_correctly_consume_and_produce_interleaving_requests() {
+    let port = TcpPort::in_range(
+        "127.0.0.1",
+        Range {
+            min: 2000,
+            max: 25000,
+        },
+    )
+    .unwrap();
+
+    tracing::info!("Running on port: {port}");
+
+    let mut read_buf = BytesMut::zeroed(20);
+    let mut write_buf = BytesMut::new();
+
+    let handle = tokio::spawn(async move {
+        let _ = run_server(port).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut socket = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+
+    // 1. Do a basic Ping test.
+    let ping = Ping::default();
+
+    Message {
+        r#type: Type::Ping as i32,
+        ping: Some(ping),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    tracing::info!("Writing: {:#?}", write_buf);
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Pong => {}
+        _ => panic!("Received incorrect response from server for ping request."),
+    }
+
+    // Upload a basic configuration with one stream.
+    let config = std::fs::read_to_string("tests/basic_config.yaml").unwrap();
+
+    let create_config_req = CreateConfigurationRequest {
+        data: config.into_bytes(),
+    };
+
+    Message {
+        r#type: Type::Createconfigurationrequest as i32,
+        create_configuration_request: Some(create_config_req),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Createconfigurationresponse => {
+            tracing::info!("Received response from server for configuration request.")
+        }
+        _ => panic!("Received incorrect response from server for create configuration request."),
+    }
+
+    // Start a subscription on that stream.
+    let create_subscription = CreateSubscriptionRequest {
+        offset: None,
+        offset_type: 0,
+        timestamp: None,
+        stream_name: "update_customer".as_bytes().to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(1024);
+
+    Message {
+        r#type: Type::Createsubscriptionrequest as i32,
+        create_subscription_request: Some(create_subscription),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    let sub_id = match Type::try_from(message.r#type).unwrap() {
+        Type::Createsubscriptionresponse => {
+            let sub_id = message
+                .create_subscription_response
+                .unwrap()
+                .subscription_id;
+
+            tracing::info!("Got the sub_id: {:#?}", sub_id);
+
+            sub_id.unwrap()
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    };
+
+    // Produce to the stream.
+
+    let payload = std::fs::read_to_string("tests/customer.json").unwrap();
+
+    let produce_request = ProduceRequest {
+        partition_key: "test_partition".as_bytes().to_vec(),
+        payload: payload.as_bytes().to_vec(),
+        stream_name: "update_customer".as_bytes().to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(1024);
+
+    Message {
+        r#type: Type::Producerequest as i32,
+        produce_request: Some(produce_request),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Produceresponse => {
+            let message = message.produce_response;
+
+            tracing::info!("Received produce response: {:#?}", message);
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    }
+
+    // Consume from the stream.
+    let take_request = TakeRecordsRequest {
+        n: 1,
+        subscription_id: sub_id,
+        stream_name: "update_customer".as_bytes().to_vec(),
+    };
+
+    let mut write_buf = BytesMut::new();
+    let mut read_buf = BytesMut::zeroed(8048);
+
+    Message {
+        r#type: Type::Takerecordsrequest as i32,
+        take_records_request: Some(take_request),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Takerecordsresponse => {
+            tracing::info!("Receieved a take records response!");
+
+            let take_records_response = message.take_records_response.unwrap();
+
+            tracing::info!("Records_Response: {:#?}", take_records_response);
+
+            for record in take_records_response.records.iter() {
+
+                tracing::info!("{}", String::from_utf8(record.data.clone()).unwrap());
+
+            }
+
+        }
+        _ => panic!("Received incorrect response from server for Create Subscription request."),
+    }
+
+    handle.abort();
+}


### PR DESCRIPTION
# Description 

Implementation of the loom interleaving of produce/consume requests for subscriptions. 

Are aware of the fact that this doesn't work right now, primarily because we have no way to "wake" a subscription when we have produced a value. 