### PR TITLE
fix: Timeouts on socket reads

### DIFF
--- a/higgins-core/Cargo.toml
+++ b/higgins-core/Cargo.toml
@@ -27,5 +27,5 @@ rkyv = "0.8.10"
 [dev-dependencies]
 get-port = "4.0.0"
 tempfile = "3.10"
-tracing-test = "0.2.5"
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 loom = { version = "0.7.2", features = ["futures"] }

--- a/higgins-core/src/lib.rs
+++ b/higgins-core/src/lib.rs
@@ -42,6 +42,8 @@ async fn process_socket(mut socket: TcpStream, broker: Arc<RwLock<Broker>>) {
 
                 let message = Message::decode(slice).unwrap();
 
+                tracing::info!("Received a message, responding.");
+
                 match Type::try_from(message.r#type).unwrap() {
                     Type::Ping => {
                         tracing::info!("Received Ping, sending Pong.");

--- a/higgins-core/tests/common/mod.rs
+++ b/higgins-core/tests/common/mod.rs
@@ -8,7 +8,7 @@ use prost::Message as _;
 use std::net::TcpStream;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-pub fn produce(stream: &[u8], partition: &[u8], payload: &[u8], socket: &mut TcpStream) {
+pub fn produce<T: std::io::Read + std::io::Write>(stream: &[u8], partition: &[u8], payload: &[u8], socket: &mut T) {
     let produce_request = ProduceRequest {
         partition_key: partition.to_vec(),
         payload: payload.to_vec(),
@@ -46,9 +46,9 @@ pub fn produce(stream: &[u8], partition: &[u8], payload: &[u8], socket: &mut Tcp
     }
 }
 
-pub fn create_subscription(
+pub fn create_subscription<T: std::io::Read + std::io::Write>(
     stream: &[u8],
-    socket: &mut TcpStream,
+    socket: &mut T,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let create_subscription = CreateSubscriptionRequest {
         offset: None,
@@ -94,9 +94,9 @@ pub fn create_subscription(
     Ok(sub_id)
 }
 
-pub fn consume(
+pub fn consume<T: std::io::Read + std::io::Write>(
     sub_id: Vec<u8>,
-    socket: &mut TcpStream,
+    socket: &mut T,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let take_request = TakeRecordsRequest {
         n: 1,
@@ -117,7 +117,8 @@ pub fn consume(
 
     let _result = socket.write_all(&write_buf).unwrap();
 
-    let n = socket.read(&mut read_buf)?;
+
+    let n = socket.read(&mut read_buf).unwrap();
 
     assert_ne!(n, 0);
 

--- a/higgins-core/tests/multi_produce.rs
+++ b/higgins-core/tests/multi_produce.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+use bytes::BytesMut;
+use get_port::{Ops, Range, tcp::TcpPort};
+use higgins::run_server;
+use higgins_codec::{
+    CreateConfigurationRequest, Message, Ping, ProduceRequest, message::Type,
+};
+use prost::Message as _;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+use tracing_test::traced_test;
+#[tokio::test]
+#[traced_test]
+async fn can_write_multiple_produce_requests() {
+    let port = TcpPort::in_range(
+        "127.0.0.1",
+        Range {
+            min: 2000,
+            max: 25000,
+        },
+    )
+    .unwrap();
+
+    tracing::info!("Running on port: {port}");
+
+    let mut read_buf = BytesMut::zeroed(20);
+    let mut write_buf = BytesMut::new();
+
+    let handle = tokio::spawn(async move {
+        let _ = run_server(port).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut socket = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+
+    // 1. Do a basic Ping test.
+    let ping = Ping::default();
+
+    Message {
+        r#type: Type::Ping as i32,
+        ping: Some(ping),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    tracing::info!("Writing: {:#?}", write_buf);
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Pong => {}
+        _ => panic!("Received incorrect response from server for ping request."),
+    }
+
+    // Upload a basic configuration with one stream.
+    let config = std::fs::read_to_string("tests/basic_config.yaml").unwrap();
+
+    let create_config_req = CreateConfigurationRequest {
+        data: config.into_bytes(),
+    };
+
+    Message {
+        r#type: Type::Createconfigurationrequest as i32,
+        create_configuration_request: Some(create_config_req),
+        ..Default::default()
+    }
+    .encode(&mut write_buf)
+    .unwrap();
+
+    let _result = socket.write_all(&write_buf).await.unwrap();
+
+    let n = tokio::time::timeout(Duration::from_secs(1), socket.read(&mut read_buf))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(n, 0);
+
+    let slice = &read_buf[0..n];
+
+    let message = Message::decode(slice).unwrap();
+
+    match Type::try_from(message.r#type).unwrap() {
+        Type::Createconfigurationresponse => {
+            tracing::info!("Received response from server for configuration request.")
+        }
+        _ => panic!("Received incorrect response from server for create configuration request."),
+    }
+
+    // Produce to the stream.
+    let payload = std::fs::read_to_string("tests/customer.json").unwrap();
+
+    for _ in 1..100 {
+        let produce_request = ProduceRequest {
+            partition_key: "test_partition".as_bytes().to_vec(),
+            payload: payload.as_bytes().to_vec(),
+            stream_name: "update_customer".as_bytes().to_vec(),
+        };
+
+        let mut write_buf = BytesMut::new();
+        let mut read_buf = BytesMut::zeroed(1024);
+
+        Message {
+            r#type: Type::Producerequest as i32,
+            produce_request: Some(produce_request),
+            ..Default::default()
+        }
+        .encode(&mut write_buf)
+        .unwrap();
+
+        let _result = socket.write_all(&write_buf).await.unwrap();
+
+        let n = tokio::time::timeout(Duration::from_secs(1), socket.read(&mut read_buf))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(n, 0);
+
+        let slice = &read_buf[0..n];
+
+        let message = Message::decode(slice).unwrap();
+
+        match Type::try_from(message.r#type).unwrap() {
+            Type::Produceresponse => {
+                let message = message.produce_response;
+
+                tracing::info!("Received produce response: {:#?}", message);
+            }
+            _ => panic!("Received incorrect response from server for Create Subscription request."),
+        }
+    }
+
+    handle.abort();
+}


### PR DESCRIPTION
# Description 

As this integration test doesn't actually work (as subscription updates are not yet implemented), We tend to timeout on receiving acks of certain produce/consume requests. This PR introduces some read timeouts to sockets as well as some other testing for checking produce requests. 