### PR TITLE
fix: Subscription listening fix

### DIFF
--- a/higgins-core/src/broker.rs
+++ b/higgins-core/src/broker.rs
@@ -207,22 +207,19 @@ impl Broker {
             let subscription = self.subscriptions.get(stream_name);
 
             if let Some(subscriptions) = subscription {
-
-                tracing::trace!("[PRODUCE] Found a subscription for this produce request." );
+                tracing::trace!("[PRODUCE] Found a subscription for this produce request.");
 
                 for (subscription_id, (notify, subscription)) in subscriptions {
                     let subscription = subscription.write().await;
 
-                tracing::trace!("[PRODUCE] Notifying the subscrition." );
-
+                    tracing::trace!("[PRODUCE] Notifying the subscrition.");
 
                     // Set the max offset of the subscription.
                     subscription.set_max_offset(partition, response.batch.offset)?;
 
                     // Notify the tasks awaiting this subscription.
                     notify.notify_waiters();
-                                    tracing::trace!("[PRODUCE] Notified the subscrition." );
-
+                    tracing::trace!("[PRODUCE] Notified the subscrition.");
 
                     tracing::info!(
                         "Updated Max offset for subscription: {}, watermark: {}",
@@ -406,13 +403,6 @@ impl Broker {
             // The runner for this subscription.
             tokio::task::spawn(async move {
                 loop {
-                    tracing::trace!("[TAKE] Awaiting the condvar.");
-
-                    // await the condvar.
-                    task_notify.notified().await;
-
-                    tracing::trace!("[TAKE] Condvar has been notified, retrieving the amount.");
-
                     let mut lock = task_subscription.write().await;
                     let broker_lock = broker.read().await;
 
@@ -486,6 +476,13 @@ impl Broker {
                             }
                         }
                     };
+
+                    tracing::trace!("[TAKE] Awaiting the condvar.");
+
+                    // await the condvar.
+                    task_notify.notified().await;
+
+                    tracing::trace!("[TAKE] Condvar has been notified, retrieving the amount.");
                 }
             });
         }

--- a/higgins-core/src/subscription/mod.rs
+++ b/higgins-core/src/subscription/mod.rs
@@ -42,7 +42,6 @@ struct SubscriptionMetadata {
 pub struct Subscription {
     db: TransactionDB,
     last_index: u64,
-
     condvar: Notify,
     pub client_counts: Vec<(u64, AtomicU64)>,
 }
@@ -62,8 +61,6 @@ impl Subscription {
     pub fn new(path: &PathBuf) -> Self {
         // Init the RocksDB implementation.
         let db: TransactionDB = TransactionDB::open_default(path).unwrap();
-
-        tokio::task::spawn(async move {});
 
         Self {
             db,

--- a/higgins-core/src/topography/config.rs
+++ b/higgins-core/src/topography/config.rs
@@ -70,7 +70,7 @@ mod test {
 
     #[test]
     fn can_deserialize_basic_yaml() {
-        let example_config = std::fs::read_to_string("tests/config.yaml").unwrap();
+        let example_config = std::fs::read_to_string("tests/basic_config.yaml").unwrap();
 
         let _config = from_yaml(example_config.as_bytes());
     }

--- a/higgins-core/tests/common/mod.rs
+++ b/higgins-core/tests/common/mod.rs
@@ -30,23 +30,6 @@ pub fn produce<T: std::io::Read + std::io::Write>(stream: &[u8], partition: &[u8
     .unwrap();
 
     let _result = socket.write_all(&write_buf).unwrap();
-
-    let n = socket.read(&mut read_buf).unwrap();
-
-    assert_ne!(n, 0);
-
-    let slice = &read_buf[0..n];
-
-    let message = Message::decode(slice).unwrap();
-
-    match Type::try_from(message.r#type).unwrap() {
-        Type::Produceresponse => {
-            let message = message.produce_response;
-
-            tracing::info!("Received produce response: {:#?}", message);
-        }
-        _ => panic!("Received incorrect response from server for Create Subscription request."),
-    }
 }
 
 

--- a/higgins-core/tests/updating_subscription.rs
+++ b/higgins-core/tests/updating_subscription.rs
@@ -95,6 +95,8 @@ fn can_update_subscription_after_created() {
 
             let message = Message::decode(slice).unwrap();
 
+            tracing::trace!("Received: {:#?}", message);
+
             match Type::try_from(message.r#type).unwrap() {
                 Type::Takerecordsresponse => {
                     let take_records_response = message.take_records_response.unwrap();
@@ -110,7 +112,16 @@ fn can_update_subscription_after_created() {
                         }
                     }
                 }
+                Type::Produceresponse => {
+                    let message = message.produce_response;
+
+                    tracing::info!("Received produce response: {:#?}", message);
+                }
                 _ => {}
+            }
+
+            if count >= NUMBER_OF_MESSAGES {
+                break;
             }
         }
     });


### PR DESCRIPTION
# Description 

Initially we had a race condition where the produce was happening before the take, in which case the notification from the produce would only update the take before it was created. In this case, we've just adjusted the wait for the condvar to after the first iteration on take. 